### PR TITLE
Attributes have value domains

### DIFF
--- a/docs/examples/SYNT_BEFOLKNING_KJOENN/SYNT_BEFOLKNING_KJOENN.json
+++ b/docs/examples/SYNT_BEFOLKNING_KJOENN/SYNT_BEFOLKNING_KJOENN.json
@@ -73,11 +73,12 @@
         {"languageCode": "no", "value": "Startdato"},
         {"languageCode": "en", "value": "Start date"}
       ],
-      "description": [
-        {"languageCode": "no", "value": "Startdato for hendelsen"},
-        {"languageCode": "en", "value": "Event start date"}
+      "description": [{"languageCode": "no", "value": "Startdato/måletidspunktet for hendelsen"}
       ],
-      "dataType": "DATE"
+      "dataType": "DATE",
+      "valueDomain": {
+        "description": [{"languageCode": "no", "value": "Dato oppgitt i dager siden 1970-01-01"}]
+      }
     },
     {
       "variableRole": "STOP_TIME",
@@ -87,10 +88,14 @@
         {"languageCode": "en", "value": "Stop date"}
       ],
       "description": [
-        {"languageCode": "no", "value": "Stoppdato/måletidspunktet for hendelsen"},
+        {"languageCode": "no", "value": "Stoppdato/sluttdato for hendelsen"},
         {"languageCode": "en", "value": "Event stop/end date"}
       ],
-      "dataType": "DATE"
+      "dataType": "DATE",
+      "valueDomain": {
+        "description": [{"languageCode": "no", "value": "Dato oppgitt i dager siden 1970-01-01"}
+        ]
+      }
     }
   ]
 }

--- a/docs/examples/SYNT_BEFOLKNING_SIVSTAND/SYNT_BEFOLKNING_SIVSTAND.json
+++ b/docs/examples/SYNT_BEFOLKNING_SIVSTAND/SYNT_BEFOLKNING_SIVSTAND.json
@@ -110,11 +110,12 @@
         {"languageCode": "no", "value": "Startdato"},
         {"languageCode": "en", "value": "Start date"}
       ],
-      "description": [
-        {"languageCode": "no", "value": "Startdato for hendelsen"},
-        {"languageCode": "en", "value": "Event start date"}
+      "description": [{"languageCode": "no", "value": "Startdato/måletidspunktet for hendelsen"}
       ],
-      "dataType": "DATE"
+      "dataType": "DATE",
+      "valueDomain": {
+        "description": [{"languageCode": "no", "value": "Dato oppgitt i dager siden 1970-01-01"}]
+      }
     },
     {
       "variableRole": "STOP_TIME",
@@ -124,10 +125,14 @@
         {"languageCode": "en", "value": "Stop date"}
       ],
       "description": [
-        {"languageCode": "no", "value": "Stoppdato/måletidspunktet for hendelsen"},
+        {"languageCode": "no", "value": "Stoppdato/sluttdato for hendelsen"},
         {"languageCode": "en", "value": "Event stop/end date"}
       ],
-      "dataType": "DATE"
+      "dataType": "DATE",
+      "valueDomain": {
+        "description": [{"languageCode": "no", "value": "Dato oppgitt i dager siden 1970-01-01"}
+        ]
+      }
     }
   ]
 }

--- a/docs/examples/SYNT_PERSON_INNTEKT/SYNT_PERSON_INNTEKT.json
+++ b/docs/examples/SYNT_PERSON_INNTEKT/SYNT_PERSON_INNTEKT.json
@@ -60,11 +60,12 @@
         {"languageCode": "no", "value": "Startdato"},
         {"languageCode": "en", "value": "Start date"}
       ],
-      "description": [
-        {"languageCode": "no", "value": "Startdato for hendelsen"},
-        {"languageCode": "en", "value": "Event start date"}
+      "description": [{"languageCode": "no", "value": "Startdato/måletidspunktet for hendelsen"}
       ],
-      "dataType": "DATE"
+      "dataType": "DATE",
+      "valueDomain": {
+        "description": [{"languageCode": "no", "value": "Dato oppgitt i dager siden 1970-01-01"}]
+      }
     },
     {
       "variableRole": "STOP_TIME",
@@ -74,10 +75,14 @@
         {"languageCode": "en", "value": "Stop date"}
       ],
       "description": [
-        {"languageCode": "no", "value": "Stoppdato/måletidspunktet for hendelsen"},
+        {"languageCode": "no", "value": "Stoppdato/sluttdato for hendelsen"},
         {"languageCode": "en", "value": "Event stop/end date"}
       ],
-      "dataType": "DATE"
+      "dataType": "DATE",
+      "valueDomain": {
+        "description": [{"languageCode": "no", "value": "Dato oppgitt i dager siden 1970-01-01"}
+        ]
+      }
     }
   ]
 }

--- a/microdata_validator/DatasetMetadataSchema.json
+++ b/microdata_validator/DatasetMetadataSchema.json
@@ -233,6 +233,7 @@
                     "dataType": {"type": "string",
                         "enum": ["STRING", "LONG", "DOUBLE", "DATE"]
                     },
+                    "valueDomain": {"$ref": "#/definitions/valueDomainType"},
                     "uriDefinition": {
                         "type": "array",
                         "items": {"type": ["string", "null"] }
@@ -247,7 +248,8 @@
                     "shortName",
                     "name",
                     "description",
-                    "dataType"
+                    "dataType",
+                    "valueDomain"
                 ]
             }
         }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "microdata-validator"
-version = "0.4.0"
+version = "0.5.0"
 description = "Python package for validating datasets in the microdata platform"
 authors = ["microdata-developers"]
 license = "Apache-2.0"

--- a/tests/resources/input_directory/INVALID_DATES_DATASET/INVALID_DATES_DATASET.json
+++ b/tests/resources/input_directory/INVALID_DATES_DATASET/INVALID_DATES_DATASET.json
@@ -110,11 +110,12 @@
         {"languageCode": "no", "value": "Startdato"},
         {"languageCode": "en", "value": "Start date"}
       ],
-      "description": [
-        {"languageCode": "no", "value": "Startdato for hendelsen"},
-        {"languageCode": "en", "value": "Event start date"}
+      "description": [{"languageCode": "no", "value": "Startdato/måletidspunktet for hendelsen"}
       ],
-      "dataType": "DATE"
+      "dataType": "DATE",
+      "valueDomain": {
+        "description": [{"languageCode": "no", "value": "Dato oppgitt i dager siden 1970-01-01"}]
+      }
     },
     {
       "variableRole": "STOP_TIME",
@@ -124,10 +125,14 @@
         {"languageCode": "en", "value": "Stop date"}
       ],
       "description": [
-        {"languageCode": "no", "value": "Stoppdato/måletidspunktet for hendelsen"},
+        {"languageCode": "no", "value": "Stoppdato/sluttdato for hendelsen"},
         {"languageCode": "en", "value": "Event stop/end date"}
       ],
-      "dataType": "DATE"
+      "dataType": "DATE",
+      "valueDomain": {
+        "description": [{"languageCode": "no", "value": "Dato oppgitt i dager siden 1970-01-01"}
+        ]
+      }
     }
   ]
 }

--- a/tests/resources/input_directory/INVALID_DATE_RANGES_DATASET/INVALID_DATE_RANGES_DATASET.json
+++ b/tests/resources/input_directory/INVALID_DATE_RANGES_DATASET/INVALID_DATE_RANGES_DATASET.json
@@ -110,11 +110,12 @@
         {"languageCode": "no", "value": "Startdato"},
         {"languageCode": "en", "value": "Start date"}
       ],
-      "description": [
-        {"languageCode": "no", "value": "Startdato for hendelsen"},
-        {"languageCode": "en", "value": "Event start date"}
+      "description": [{"languageCode": "no", "value": "Startdato/måletidspunktet for hendelsen"}
       ],
-      "dataType": "DATE"
+      "dataType": "DATE",
+      "valueDomain": {
+        "description": [{"languageCode": "no", "value": "Dato oppgitt i dager siden 1970-01-01"}]
+      }
     },
     {
       "variableRole": "STOP_TIME",
@@ -124,10 +125,14 @@
         {"languageCode": "en", "value": "Stop date"}
       ],
       "description": [
-        {"languageCode": "no", "value": "Stoppdato/måletidspunktet for hendelsen"},
+        {"languageCode": "no", "value": "Stoppdato/sluttdato for hendelsen"},
         {"languageCode": "en", "value": "Event stop/end date"}
       ],
-      "dataType": "DATE"
+      "dataType": "DATE",
+      "valueDomain": {
+        "description": [{"languageCode": "no", "value": "Dato oppgitt i dager siden 1970-01-01"}
+        ]
+      }
     }
   ]
 }

--- a/tests/resources/input_directory/MISSING_IDENTIFIER_DATASET/MISSING_IDENTIFIER_DATASET.json
+++ b/tests/resources/input_directory/MISSING_IDENTIFIER_DATASET/MISSING_IDENTIFIER_DATASET.json
@@ -43,11 +43,12 @@
           {"languageCode": "no", "value": "Startdato"},
           {"languageCode": "en", "value": "Start date"}
         ],
-        "description": [
-          {"languageCode": "no", "value": "Startdato for hendelsen"},
-          {"languageCode": "en", "value": "Event start date"}
+        "description": [{"languageCode": "no", "value": "Startdato/måletidspunktet for hendelsen"}
         ],
-        "dataType": "DATE"
+        "dataType": "DATE",
+        "valueDomain": {
+          "description": [{"languageCode": "no", "value": "Dato oppgitt i dager siden 1970-01-01"}]
+        }
       },
       {
         "variableRole": "STOP_TIME",
@@ -57,10 +58,14 @@
           {"languageCode": "en", "value": "Stop date"}
         ],
         "description": [
-          {"languageCode": "no", "value": "Stoppdato/måletidspunktet for hendelsen"},
+          {"languageCode": "no", "value": "Stoppdato/sluttdato for hendelsen"},
           {"languageCode": "en", "value": "Event stop/end date"}
         ],
-        "dataType": "DATE"
+        "dataType": "DATE",
+        "valueDomain": {
+          "description": [{"languageCode": "no", "value": "Dato oppgitt i dager siden 1970-01-01"}
+          ]
+        }
       }
     ]
   }

--- a/tests/resources/input_directory/SYNT_BEFOLKNING_KJOENN/SYNT_BEFOLKNING_KJOENN.json
+++ b/tests/resources/input_directory/SYNT_BEFOLKNING_KJOENN/SYNT_BEFOLKNING_KJOENN.json
@@ -73,11 +73,12 @@
         {"languageCode": "no", "value": "Startdato"},
         {"languageCode": "en", "value": "Start date"}
       ],
-      "description": [
-        {"languageCode": "no", "value": "Startdato for hendelsen"},
-        {"languageCode": "en", "value": "Event start date"}
+      "description": [{"languageCode": "no", "value": "Startdato/måletidspunktet for hendelsen"}
       ],
-      "dataType": "DATE"
+      "dataType": "DATE",
+      "valueDomain": {
+        "description": [{"languageCode": "no", "value": "Dato oppgitt i dager siden 1970-01-01"}]
+      }
     },
     {
       "variableRole": "STOP_TIME",
@@ -87,10 +88,14 @@
         {"languageCode": "en", "value": "Stop date"}
       ],
       "description": [
-        {"languageCode": "no", "value": "Stoppdato/måletidspunktet for hendelsen"},
+        {"languageCode": "no", "value": "Stoppdato/sluttdato for hendelsen"},
         {"languageCode": "en", "value": "Event stop/end date"}
       ],
-      "dataType": "DATE"
+      "dataType": "DATE",
+      "valueDomain": {
+        "description": [{"languageCode": "no", "value": "Dato oppgitt i dager siden 1970-01-01"}
+        ]
+      }
     }
   ]
 }

--- a/tests/resources/input_directory/SYNT_BEFOLKNING_SIVSTAND/SYNT_BEFOLKNING_SIVSTAND.json
+++ b/tests/resources/input_directory/SYNT_BEFOLKNING_SIVSTAND/SYNT_BEFOLKNING_SIVSTAND.json
@@ -110,11 +110,12 @@
         {"languageCode": "no", "value": "Startdato"},
         {"languageCode": "en", "value": "Start date"}
       ],
-      "description": [
-        {"languageCode": "no", "value": "Startdato for hendelsen"},
-        {"languageCode": "en", "value": "Event start date"}
+      "description": [{"languageCode": "no", "value": "Startdato/måletidspunktet for hendelsen"}
       ],
-      "dataType": "DATE"
+      "dataType": "DATE",
+      "valueDomain": {
+        "description": [{"languageCode": "no", "value": "Dato oppgitt i dager siden 1970-01-01"}]
+      }
     },
     {
       "variableRole": "STOP_TIME",
@@ -124,10 +125,14 @@
         {"languageCode": "en", "value": "Stop date"}
       ],
       "description": [
-        {"languageCode": "no", "value": "Stoppdato/måletidspunktet for hendelsen"},
+        {"languageCode": "no", "value": "Stoppdato/sluttdato for hendelsen"},
         {"languageCode": "en", "value": "Event stop/end date"}
       ],
-      "dataType": "DATE"
+      "dataType": "DATE",
+      "valueDomain": {
+        "description": [{"languageCode": "no", "value": "Dato oppgitt i dager siden 1970-01-01"}
+        ]
+      }
     }
   ]
 }

--- a/tests/resources/input_directory/SYNT_PERSON_INNTEKT/SYNT_PERSON_INNTEKT.json
+++ b/tests/resources/input_directory/SYNT_PERSON_INNTEKT/SYNT_PERSON_INNTEKT.json
@@ -60,11 +60,12 @@
         {"languageCode": "no", "value": "Startdato"},
         {"languageCode": "en", "value": "Start date"}
       ],
-      "description": [
-        {"languageCode": "no", "value": "Startdato for hendelsen"},
-        {"languageCode": "en", "value": "Event start date"}
+      "description": [{"languageCode": "no", "value": "Startdato/måletidspunktet for hendelsen"}
       ],
-      "dataType": "DATE"
+      "dataType": "DATE",
+      "valueDomain": {
+        "description": [{"languageCode": "no", "value": "Dato oppgitt i dager siden 1970-01-01"}]
+      }
     },
     {
       "variableRole": "STOP_TIME",
@@ -74,10 +75,14 @@
         {"languageCode": "en", "value": "Stop date"}
       ],
       "description": [
-        {"languageCode": "no", "value": "Stoppdato/måletidspunktet for hendelsen"},
+        {"languageCode": "no", "value": "Stoppdato/sluttdato for hendelsen"},
         {"languageCode": "en", "value": "Event stop/end date"}
       ],
-      "dataType": "DATE"
+      "dataType": "DATE",
+      "valueDomain": {
+        "description": [{"languageCode": "no", "value": "Dato oppgitt i dager siden 1970-01-01"}
+        ]
+      }
     }
   ]
 }


### PR DESCRIPTION
# ATTRIBUTES HAVE VALUE DOMAINS

All attribute variables in the 1.5 datastore have simple described valuedomains. This should also be the case in M2.0 to avoid breaking changes.

* Updated schema
* Updated testdata
* Updated docs/examples
* Bumped to version 0.5.0