### PR TITLE
Improved temp file delete

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -67,7 +67,7 @@ else:
     print("Dataset is invalid :(")
  ```
 
-The validate function will temporarily generate some files in order to validate your dataset. To do this, it will create a working directory in the same location as your script. Therefore, it is important that you have writing permissions in your directory. You can also choose to define the location of this directory yourself using the ```working_directory```-parameter.
+The validate function will temporarily generate some files in order to validate your dataset. To do this, it will create a working directory in the same location as your script, and delete it once it is done. Therefore, it is important that you have writing permissions in your directory. You can also choose to define the location of this directory yourself using the ```working_directory```-parameter. If you choose to do this, the validate function will only delete the files it generates.
 
 ```py
 from microdata_validator import validate
@@ -83,10 +83,23 @@ if not validation_errors:
 else:
     print("Dataset is invalid :(")
  ```
+If you wish to keep the temporary files after the validator has run, you can do this with the ```keep_temporary_files```-parameter:
+```py
+from microdata_validator import validate
 
- **BE CAREFUL:**
-You can set the ```delete_working_directory```-parameter to True, if you want the script to delete the generated files in the working directory after validating. These files will be lost forever.
+validation_errors = validate(
+    "my-dataset-name",
+    input_directory="/my/input/directory",
+    working_directory="/my/working/directory",
+    keep_temporary_files=True
+)
 
+if not validation_errors:
+    print("My dataset is valid")
+else:
+    print("Dataset is invalid :(")
+ ```
+ 
 ## Validate metadata
 What if your data is not yet done, but you want to start generating and validating your metadata?
 You can validate the metadata by itself with the validate_metadata-function:

--- a/microdata_validator/__init__.py
+++ b/microdata_validator/__init__.py
@@ -18,7 +18,11 @@ def validate(dataset_name: str,
              keep_temporary_files: bool = False,
              metadata_ref_directory: str = None,
              print_errors_to_file: bool = False) -> bool:
+    """
+    Validate a dataset and return a list of errors. If the dataset is valid, the list will be empty.
+    """
 
+    # Generate working directory if not supplied
     if working_directory:
         generated_working_directory = False
         working_directory_path = Path(working_directory)
@@ -27,10 +31,12 @@ def validate(dataset_name: str,
         working_directory_path = Path(str(uuid.uuid4()))
         os.mkdir(working_directory_path)
 
+    # Make paths for input and ref directory
     input_directory_path = Path(input_directory)
     if metadata_ref_directory is not None:
         metadata_ref_directory = Path(metadata_ref_directory)
 
+    # Run reader and validator
     data_errors = []
     try:
         dataset_reader.run_reader(
@@ -53,6 +59,7 @@ def validate(dataset_name: str,
         # Raise unexpected exceptions to user
         raise e
 
+    # Delete temporary files
     if not keep_temporary_files:
         generated_files = [
             f"{dataset_name}.csv",
@@ -78,6 +85,9 @@ def validate(dataset_name: str,
 
 def validate_metadata(metadata_file_path: str,
                       metadata_ref_directory: str = None) -> list:
+    """
+    Validate a metadata file and return a list of errors. If the metadata is valid, the list will be empty.
+    """
     try:
         metadata_file_path = Path(metadata_file_path)
         if metadata_ref_directory is None:
@@ -96,6 +106,10 @@ def validate_metadata(metadata_file_path: str,
 
 def inline_metadata(metadata_file_path: str, metadata_ref_directory: str,
                     output_file_path: str = None) -> Path:
+    """
+    Generate a metadata file with inlined references from a supplied metadata file and a reference directory.
+    Returns the path to the generated file. Throws an error if the metadata is invalid.
+    """
     if output_file_path is None:
         output_file_path = Path(
             f"{metadata_file_path.strip('.json')}_inlined.json"

--- a/microdata_validator/__init__.py
+++ b/microdata_validator/__init__.py
@@ -73,12 +73,32 @@ def validate(dataset_name: str,
                 if file not in generated_files
             ]
             if not unknown_files:
-                shutil.rmtree(working_directory_path)
+                try:
+                    shutil.rmtree(working_directory_path)
+                except Exception as e:
+                    logger.error(
+                        "An exception occured while attempting to delete"
+                        "temporary files: {e}"  
+                    )
+                    pass
+            else:
+                try:
+                    os.remove(working_directory_path / file)
+                except FileNotFoundError:
+                    logger.error(
+                        "Could not find file {file} in working directory "
+                        "when attempting to delete temporary files."    
+                    )
+                    pass
         else:
             for file in generated_files:
                 try:
                     os.remove(working_directory_path / file)
                 except FileNotFoundError:
+                    logger.error(
+                        "Could not find file {file} in working directory "
+                        "when attempting to delete temporary files."    
+                    )
                     pass
     return data_errors
 

--- a/microdata_validator/utils.py
+++ b/microdata_validator/utils.py
@@ -40,7 +40,7 @@ def inline_metadata_references(metadata_file_path: Path,
             "Supplied reference directory is invalid"
             f" '{metadata_ref_directory}'"
         )
-    logger.info(f'Reading metadata from file "{metadata_file_path}"')
+    logger.debug(f'Reading metadata from file "{metadata_file_path}"')
     metadata: dict = load_json(metadata_file_path)
     recursive_ref_insert(metadata)
     return metadata

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "microdata-validator"
-version = "0.8.0"
+version = "1.0.0"
 description = "Python package for validating datasets in the microdata platform"
 authors = ["microdata-developers"]
 license = "Apache-2.0"

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -23,6 +23,7 @@ def test_validate_valid_dataset():
         data_errors = validate(
             valid_dataset_name,
             working_directory=WORKING_DIRECTORY,
+            keep_temporary_files=True,
             input_directory=INPUT_DIRECTORY
         )
         actual_files = get_working_directory_files()
@@ -36,10 +37,37 @@ def test_validate_valid_dataset():
             assert file in actual_files
 
 
+def test_validate_valid_dataset_delete_temporary_files():
+    for valid_dataset_name in VALID_DATASET_NAMES:
+        data_errors = validate(
+            valid_dataset_name,
+            working_directory=WORKING_DIRECTORY,
+            input_directory=INPUT_DIRECTORY
+        )
+        temp_files = get_working_directory_files()
+        assert not data_errors
+        assert temp_files == ['.gitkeep']
+
+
+def test_validate_valid_dataset_delete_generated_dir():
+    for valid_dataset_name in VALID_DATASET_NAMES:
+        data_errors = validate(
+            valid_dataset_name,
+            input_directory=INPUT_DIRECTORY
+        )
+        temp_files = [
+            dir for dir in os.listdir()
+            if os.path.isdir(dir) and dir[0] != '.'
+        ]
+        assert not data_errors
+        assert temp_files == ['tests', 'docs', 'microdata_validator']
+
+
 def test_validate_valid_dataset_ref():
     data_errors = validate(
         VALID_DATASET_REF,
         working_directory=WORKING_DIRECTORY,
+        keep_temporary_files=True,
         input_directory=INPUT_DIRECTORY,
         metadata_ref_directory=REF_DIRECTORY
     )
@@ -59,12 +87,11 @@ def test_validate_valid_dataset_delete_working_files():
         data_errors = validate(
             valid_dataset_name,
             working_directory=WORKING_DIRECTORY,
-            input_directory=INPUT_DIRECTORY,
-            delete_working_directory=True
+            input_directory=INPUT_DIRECTORY
         )
         actual_files = get_working_directory_files()
         assert not data_errors
-        assert not actual_files
+        assert actual_files == ['.gitkeep']
 
 
 def test_dataset_does_not_exist():
@@ -112,10 +139,7 @@ def test_invalid_date_ranges():
 
 
 def get_working_directory_files() -> list:
-    return [
-        file for file in os.listdir(WORKING_DIRECTORY)
-        if file != '.gitkeep'
-    ]
+    return [file for file in os.listdir(WORKING_DIRECTORY)]
 
 
 def teardown_function():

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -60,7 +60,8 @@ def test_validate_valid_dataset_delete_generated_dir():
             if os.path.isdir(dir) and dir[0] != '.'
         ]
         assert not data_errors
-        assert temp_files == ['tests', 'docs', 'microdata_validator']
+        for file in temp_files:
+            assert file in ['tests', 'docs', 'microdata_validator']
 
 
 def test_validate_valid_dataset_ref():


### PR DESCRIPTION
# IMPROVED TEMP FILE DELETE

Users disliked that the generated temp files/directories persisted by default. Changed the behaviour so:
* **If no working directory is supplied**, a temporary directory will be made at project root. This directory is deleted in its entirety after validation. If any files the validator has not itself generated appears in this directory before deletion, it will not delete the directory, but instead delete the individual files.
* **If working directory is supplied** the validator will only delete the files it generates.
* The optional parameter `keep_temporary_files` can be set to True to avoid deleting the temporary files

## Other notes
* Added docstrings to public functions
* Updated docs
* Updated unit tests
* Bumped version to 1.0.0 as these changes are breaking, and the package is deemed functional and ready for its first major release.