### PR TITLE
Schema empty codelist fix

### DIFF
--- a/microdata_validator/DatasetMetadataSchema.json
+++ b/microdata_validator/DatasetMetadataSchema.json
@@ -29,6 +29,7 @@
       "properties": {
         "codeItems": {
           "type": "array",
+          "minItems": 1,
           "items": {
             "type": "object",
             "properties": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "microdata-validator"
-version = "2.1.0"
+version = "3.0.0"
 description = "Python package for validating datasets in the microdata platform"
 authors = ["microdata-developers"]
 license = "Apache-2.0"

--- a/tests/resources/input_directory/EMPTY_CODELIST_DATASET/EMPTY_CODELIST_DATASET.json
+++ b/tests/resources/input_directory/EMPTY_CODELIST_DATASET/EMPTY_CODELIST_DATASET.json
@@ -1,0 +1,84 @@
+{
+    "shortName": "SYNT_BEFOLKNING_SIVSTAND",
+    "temporalityType": "EVENT",
+    "populationDescription": [{"languageCode": "no", "value": "Alle personer registrert bosatt i Norge"}],
+    "spatialCoverageDescription": [{"languageCode": "no", "value": "Norge"}],
+    "dataRevision": {
+      "description": [{"languageCode": "no","value": "Første publisering."}],
+      "temporalEndOfSeries": false
+    },
+    "identifierVariables": [
+      {
+        "shortName": "PERSONID_1",
+        "name": [{"languageCode": "no", "value": "Personidentifikator"}],
+        "description": [{"languageCode": "no","value": "Identifikator for person i Microdata"}],
+        "dataType": "STRING",
+        "unitType": {
+          "shortName": "PERSON",
+          "name": [{"languageCode": "no", "value": "Person"}],
+          "description": [{"languageCode": "no", "value": "Statistisk enhet er person (individ, enkeltmenenske)"}]
+        },
+        "format": "RandomUInt48",
+        "valueDomain": {
+          "shortName": "PERSONID_1",
+          "description": [{"languageCode": "no", "value":"Pseudonymisert personnummer"}]
+        }
+      }
+    ],
+    "measureVariables": [
+      {
+        "shortName": "SYNT_BEFOLKNING_SIVSTAND",
+        "name": [{"languageCode": "no", "value": "Sivilstand"}],
+        "description": [{"languageCode": "no", "value": "Sivilstand i forhold til ekteskapslovgivningen"}],
+        "subjectFields": [
+          {
+            "shortName": "BEFOLKNING",
+            "name": [{"languageCode": "no", "value": "Befolkning"}],
+            "description": [{"languageCode": "no", "value": "Befolkning"}]
+          }
+        ],
+        "dataType": "STRING",
+        "uriDefinition": ["https://www.ssb.no/a/metadata/conceptvariable/vardok/91/nb"],
+        "valueDomain": {
+          "uriDefinition": ["https://www.ssb.no/klass/klassifikasjoner/19"],
+          "codeList": {
+            "codeItems": []
+          }
+        }
+      }
+    ],
+    "attributeVariables": [
+      {
+        "variableRole": "START_TIME",
+        "shortName": "START",
+        "name": [
+          {"languageCode": "no", "value": "Startdato"},
+          {"languageCode": "en", "value": "Start date"}
+        ],
+        "description": [{"languageCode": "no", "value": "Startdato/måletidspunktet for hendelsen"}
+        ],
+        "dataType": "DATE",
+        "valueDomain": {
+          "description": [{"languageCode": "no", "value": "Dato oppgitt i dager siden 1970-01-01"}]
+        }
+      },
+      {
+        "variableRole": "STOP_TIME",
+        "shortName": "STOP",
+        "name": [
+          {"languageCode": "no", "value": "Stoppdato"},
+          {"languageCode": "en", "value": "Stop date"}
+        ],
+        "description": [
+          {"languageCode": "no", "value": "Stoppdato/sluttdato for hendelsen"},
+          {"languageCode": "en", "value": "Event stop/end date"}
+        ],
+        "dataType": "DATE",
+        "valueDomain": {
+          "description": [{"languageCode": "no", "value": "Dato oppgitt i dager siden 1970-01-01"}
+          ]
+        }
+      }
+    ]
+  }
+  

--- a/tests/test_validate_metadata.py
+++ b/tests/test_validate_metadata.py
@@ -10,12 +10,18 @@ VALID_METADATA_FILE_PATHS = [
     f'{INPUT_DIR}/SYNT_BEFOLKNING_SIVSTAND/SYNT_BEFOLKNING_SIVSTAND.json',
     f'{INPUT_DIR}/SYNT_PERSON_INNTEKT/SYNT_PERSON_INNTEKT.json'
 ]
-VALID_METADATA_REF_PATH = f'{INPUT_DIR}/SYNT_BEFOLKNING_KJOENN/SYNT_BEFOLKNING_KJOENN.json'
+VALID_METADATA_REF_PATH = (
+    f'{INPUT_DIR}/SYNT_BEFOLKNING_KJOENN/SYNT_BEFOLKNING_KJOENN.json'
+)
 NO_SUCH_METADATA_FILE = 'NO/SUCH/FILE'
 MISSING_IDENTIFIER_METADATA_FILE_PATH = (
     f'{INPUT_DIR}/MISSING_IDENTIFIER_DATASET/MISSING_IDENTIFIER_DATASET.json'
 )
+EMPTY_CODELIST_METADATA_FILE_PATH = (
+    f'{INPUT_DIR}/EMPTY_CODELIST_DATASET/EMPTY_CODELIST_DATASET.json'
+)
 REF_DIRECTORY = 'tests/resources/ref_directory'
+
 
 def test_validate_valid_metadata():
     for metadata_file_path in VALID_METADATA_FILE_PATHS:
@@ -34,16 +40,29 @@ def test_validate_valid_metadata_ref():
 
 
 def test_validate_invalid_metadata():
-        data_errors = validate_metadata(
-            MISSING_IDENTIFIER_METADATA_FILE_PATH
+    data_errors = validate_metadata(
+        MISSING_IDENTIFIER_METADATA_FILE_PATH
+    )
+    assert data_errors == [
+        "required: 'identifierVariables' is a required property"
+    ]
+
+
+def test_validate_empty_codelist():
+    data_errors = validate_metadata(
+        EMPTY_CODELIST_METADATA_FILE_PATH
+    )
+    assert data_errors == [
+        (
+            'properties.measureVariables.items.properties'
+            '.valueDomain.properties.codeList.properties.codeItems.minItems: '
+            '[] is too short'
         )
-        assert data_errors == [
-            "required: 'identifierVariables' is a required property"
-        ]
+    ]
 
 
 def test_validate_metadata_does_not_exist():
-    with pytest.raises(FileNotFoundError) as e:
+    with pytest.raises(FileNotFoundError):
         validate_metadata(
             NO_SUCH_METADATA_FILE
         )


### PR DESCRIPTION
# SCHEMA: EMPTY CODELIST FIX

schema validated valuedomains as valid even when code list was empty. Added minItems for codelist in schema to 1, and wrote unit test.

Bumped from 2.1.0 to 3.0.0