### PR TITLE
missingValues field bugfix

### DIFF
--- a/microdata_validator/metadata_model.py
+++ b/microdata_validator/metadata_model.py
@@ -90,14 +90,14 @@ class ValueDomain:
 
     def __init__(self, value_domain_dict: dict):
         self.is_enumerated_value_domain = (
-            "codeList" in value_domain_dict
-            and "description" not in value_domain_dict
-            and "unitOfMeasure" not in value_domain_dict
+                "codeList" in value_domain_dict
+                and "description" not in value_domain_dict
+                and "unitOfMeasure" not in value_domain_dict
         )
         self.is_described_value_domain = (
-            "description" in value_domain_dict
-            and "codeList" not in value_domain_dict
-            and "missingValues" not in value_domain_dict
+                "description" in value_domain_dict
+                and "codeList" not in value_domain_dict
+                and "missingValues" not in value_domain_dict
         )
         if self.is_described_value_domain:
             self.description = value_domain_dict.get("description")
@@ -136,11 +136,12 @@ class ValueDomain:
             dict_representation = {
                 "codeList": [
                     code_item.to_dict() for code_item in self.code_list
-                ],
-                "missingValues": [
-                    missing_value for missing_value in self.missing_values
                 ]
             }
+            if self.missing_values is not None:
+                dict_representation["missingValues"] = [
+                    missing_value for missing_value in self.missing_values
+                ]
         return {
             key: value for key, value in dict_representation.items()
             if value not in [None]
@@ -254,10 +255,10 @@ class Variable:
                 'Can not delete Variable'
             )
         if (
-            self.name != other.name or
-            self.data_type != other.data_type or
-            self.format != other.format or
-            self.variable_role != other.variable_role
+                self.name != other.name or
+                self.data_type != other.data_type or
+                self.format != other.format or
+                self.variable_role != other.variable_role
         ):
             raise PatchingError(
                 'Illegal change to one of these variable fields: '
@@ -338,9 +339,9 @@ class Metadata:
                 'Can not patch with NoneType Metadata'
             )
         if (
-            self.name != other.name or
-            self.temporality != other.temporality or
-            self.language_code != other.language_code
+                self.name != other.name or
+                self.temporality != other.temporality or
+                self.language_code != other.language_code
         ):
             raise PatchingError(
                 'Can not change these metadata fields '

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "microdata-validator"
-version = "3.0.1"
+version = "3.1.0"
 description = "Python package for validating datasets in the microdata platform"
 authors = ["microdata-developers"]
 license = "Apache-2.0"

--- a/tests/resources/metadata_model/SYNT_BEFOLKNING_KJOENN_enumerated.json
+++ b/tests/resources/metadata_model/SYNT_BEFOLKNING_KJOENN_enumerated.json
@@ -62,9 +62,6 @@
               "category": "Kj\u00f8nn ukjent",
               "code": "0"
             }
-          ],
-          "missingValues": [
-            "0"
           ]
         }
       }

--- a/tests/resources/metadata_model/SYNT_BEFOLKNING_KJOENN_enumerated_patched.json
+++ b/tests/resources/metadata_model/SYNT_BEFOLKNING_KJOENN_enumerated_patched.json
@@ -62,9 +62,6 @@
               "category": "Kj\u00f8nn ukjent2",
               "code": "0"
             }
-          ],
-          "missingValues": [
-            "0"
           ]
         }
       }

--- a/tests/resources/metadata_model/SYNT_BEFOLKNING_KJOENN_enumerated_update.json
+++ b/tests/resources/metadata_model/SYNT_BEFOLKNING_KJOENN_enumerated_update.json
@@ -62,9 +62,6 @@
               "category": "Kj\u00f8nn ukjent2",
               "code": "0"
             }
-          ],
-          "missingValues": [
-            "0"
           ]
         }
       }


### PR DESCRIPTION
This field is not required and the code fails with 
```
>               "missingValues": [
                    missing_value for missing_value in self.missing_values
                ]
            }
E           TypeError: 'NoneType' object is not iterable
```
in to_dict() method of ValueDomain class.