### PR TITLE
Update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Python package for validating datasets in the microdata platform.
 ### **Dataset description**
 A dataset as defined in microdata consists of one data file, and one metadata file.
 
-The data file is a csv-file seperated by semicolons. A valid example would be:
+The data file is a csv file seperated by semicolons. A valid example would be:
 ```csv
 000000000000001;123;2020-01-01;2020-12-31;
 000000000000002;123;2020-01-01;2020-12-31;
@@ -15,7 +15,7 @@ The data file is a csv-file seperated by semicolons. A valid example would be:
 ```
 Read more about the data format and columns in [the documentation](/docs).
 
-The metadata files should be in json format. The requirements for the metadata is best described through the [json schema](/microdata_validator/DatasetMetadataSchema.json), [the examples](/docs/examples), and [the documentation](/docs).
+The metadata files should be in json format. The requirements for the metadata is best described through the [json schema](/microdata_validator/schema/dataset_metadata_schema.json), [the examples](/docs/examples), and [the documentation](/docs).
 
 ### **Basic usage**
 
@@ -26,9 +26,10 @@ my-input-directory/
         MY_DATASET_NAME.csv
         MY_DATASET_NAME.json
 ```
+Note that the filename only allows upper case A-Z number 0-9 and underscores.
 
 
-Install microdata-validator through pip:
+Then use pip to install microdata-validator:
 ```
 pip install microdata-validator
 ```
@@ -38,7 +39,7 @@ Import microdata-validator in your script and validate your files:
 from microdata_validator import validate
 
 validation_errors = validate(
-    "my-dataset-name",
+    "MY_DATASET_NAME",
     input_directory="path/to/my-input-directory"
 )
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ my-input-directory/
         MY_DATASET_NAME.csv
         MY_DATASET_NAME.json
 ```
-Note that the filename only allows upper case A-Z number 0-9 and underscores.
+Note that the filename only allows upper case letters A-Z, number 0-9 and underscores.
 
 
 Then use pip to install microdata-validator:

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,10 +1,11 @@
 ## THE METADATA MODEL
 _______
 In addition to the examples of metadata json files present in this repository, this document briefly describes the fields in the metadata model.
+
 ### ROOT LEVEL FIELDS
 These fields describe the dataset as a whole.
-* **shortName**: Name of the dataset
-* **temporalityType**: The temporality type of the dataset. Must be one of FIXED, ACCUMULATED, STATUS og EVENT.
+* **temporalityType**: The temporality type of the dataset. Must be one of FIXED, ACCUMULATED, STATUS or EVENT.
+* **sensitivityLevel**: The sensitivity of the data in the dataset. Must be one of: PERSON_GENERAL, PERSON_SPECIAL, PUBLIC or NONPUBLIC
 * **spatialCoverageDescription**: The geographic area relevant to the data.
 * **populationDescription**: Description of the dataset's population.
 
@@ -12,41 +13,27 @@ These fields describe the dataset as a whole.
 ### DATAREVISION
 These fields describe the current version of the dataset.
 * **description**: Description of this version of the dataset.
-* **temporalEndOfSeries**: Is this the final updates for this dataset? [True | False]
+* **temporalEndOfSeries**: Is this the final update for this dataset? [True | False]
 
 ### IDENTIFIER VARIABLES
-Description of the indentifier column of the dataset. It is represented as a list in the metadata model, but currently only one identifier is allowed per dataset.
-* **shortName**: Machine readable name for the identifier column. Example: "PERSONID_1".
-* **name**: Human readable name for the identifier colum. Example: "Personidentifikator".
-* **description**: Description of the column contents. Example: "Pseudonymisert fødselsnummer"
-* **dataType**: DataType for the values in the column. One of: ["STRING", "LONG"]
-* **format**: More detailed description of the values. For example a regular expression.
-* **uriDefinition**: Link to external resource describing the identifier.
-* **unitType**: See definition below.
-* **valueDomain**: See definition below.
+Description of the indentifier column of the dataset. It is represented as a list in the metadata model, but currently only one identifier is allowed per dataset. The identifiers are always based on a unit. A unit is centrally defined to make joining datasets across datastores easy.
+* **unitType**: The unitType for this dataset identifier column. Must be one of: FAMILIE, FORETAK, HUSHOLDNING, JOBB, KJORETOY, KOMMUNE, KURS, PERSON or VIRKSOMHET.
 
 ### MEASURE VARIABLES
 Description of the measure column of the dataset. It is represented as a list in the metadata model, but currently only one measure is allowed per dataset.
-* **shortName**: Machine readable name for the measure. Is also used as variable name in the ROSE client. Example: INNTEKT_AKSJEUTBYTTE.
-* **name**: Human readable name(Label) of the measure column. Used as the column label in the ROSE client. Example: "Aksjeutbytte".
+* **name**: Human readable name(Label) of the measure column. This should be similar to your dataset name. Example for PERSON_INNTEKT.json: "Person inntekt".
 * **description**: Description of the column contents. Example: "Skattepliktig og skattefritt utbytte i... "
 * **dataType**: DataType for the values in the column. One of: ["STRING", "LONG", "DOUBLE", "DATE"]
-* **format**: More detailed description of the values. For example a regular expression.
-* **uriDefinition**: Link to external resource describing the measure.
-* **unitType**: See definition below.
+* **format (Optional)**: More detailed description of the values. For example a regular expression.
+* **uriDefinition (Optional)**: Link to external resource describing the measure.
 * **valueDomain**: See definition below.
 
-### ATTRIBUTE VARIABLES
-Description of the attribute columns. For now the only valid values are START_TIME og STOP_TIME
-* **variableRole**: One of: ["START_TIME", "STOP_TIME"]
-* **shortName**: Machine readable name for the measure. 
-* **name**: Human readable name(Label) of the attribute column. Used as the column label in the ROSE client. Example: "Startdato".
-* **description**: Description of the column contents.
-* **dataType**: DataType for the values in the column. One of: ["STRING", "LONG", "DOUBLE", "DATE"]
-* **format**: More detailed description of the values. For example a regular expression.
-* **uriDefinition**: Link to external resource describing the measure.
-* **unitType**: See definition below.
-* **valueDomain**: See definition below.
+
+### MEASURE VARIABLES (with unitType)
+You might find that some of your datasets contain a unitType in the measure column as well. Let's say you have a dataset PERSON_MOR where the identifier-column is a population of unitType "PERSON", and the measure column is a population of unitType "PERSON". The measure here is representing the populations mothers. Then you may define it as such:
+* **unitType**: The unitType for this dataset measure column. Must be one of: FAMILIE, FORETAK, HUSHOLDNING, JOBB, KJORETOY, KOMMUNE, KURS, PERSON or VIRKSOMHET.
+* **name**: Human readable name(Label) of the measure column. This should be similar to your dataset name. Example for PERSON_MOR.json: "Person mor".
+* **description**: Description of the column contents. Example: "Personens registrerte biologiske mor... "
 
 
 ### VALUE DOMAIN
@@ -99,12 +86,16 @@ The second example belongs to the measure variable of a dataset where the measur
 We expect all values in this dataset to be either "1" or "2", as this dataset only considers "Male" or "Female". But we also expect a code "0" to be present in the dataset, where it represents "Unknown". A row with "0" as measure is therefore not considered invalid. A value domain with a code list like this is what we would call an __enumerated value domain.
 
 
-### UNIT TYPE
-Description of the unit the data describes. A "fødselsnummer" can be used to identify a PERSON. Another example would be an "organisasjonsnummer" that would be used to identify a "FORETAK".
-* **shortName**: Machine readable name.
-* **name**: Human readable name.
-* **description**: Description of the unit type.
-
+### UNIT TYPES
+* **PERSON**: Representation of a person in the microdata platform. Columns with this unit type should contain FNR.
+* **FAMILIE**: Representation of a family in the microdata platform. Columns with this unit type should contain FNR.
+* **FORETAK**: Representation of a foretak in the microdata platform. Columns with this unit type should contain ORGNR.
+* **VIRKSOMHET**: Representation of a virksomhet in the microdata platform. Columns with this unit type should contain ORGNR.
+* **HUSHOLDNING**: Representation of a husholdning in the microdata platform. Columns with this unit type should contain FNR.
+* **JOBB**: Representation of a job in the microdata platform. Columns with this unit type should contain FNR_ORGNR. FNR belongs to the employee and ORGNR belongs to the employer.
+* **KOMMUNE**: Representation of a kommune in the microdata platform. Columns with this unit type should contain a valid kommune number.
+* **KURS**: Representation of a course in the microdata platform. Columns with this unit type should contain FNR_KURSID. Where FNR belongs to the participant and KURSID is the NUDB course id.
+* **KJORETOY**: Representation of a vehicle in the microdata platform. Columns with this unit type should contain FNR_REGNR. Where FNR is the owner of the vehicle, and REGNR is the registration number for the vehicle.
 
 ## VALIDATION
 
@@ -125,7 +116,7 @@ Example:
 ```
 
 This dataset describes a group of persons gross income accumulated yearly. The columns can be described like this:
-* Identifier: fødselsnummer
+* Identifier: FNR
 * Measure: Accumulated gross income for the time period
 * Start: start of time period
 * Stop: end of time period

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,7 +30,7 @@ Description of the measure column of the dataset. It is represented as a list in
 
 
 ### MEASURE VARIABLES (with unitType)
-You might find that some of your datasets contain a unitType in the measure column as well. Let's say you have a dataset PERSON_MOR where the identifier-column is a population of unitType "PERSON", and the measure column is a population of unitType "PERSON". The measure here is representing the populations mothers. Then you may define it as such:
+You might find that some of your datasets contain a unitType in the measure column as well. Let's say you have a dataset PERSON_MOR where the identifier column is a population of unitType "PERSON", and the measure column is a population of unitType "PERSON". The measure here is representing the populations mothers. Then you may define it as such:
 * **unitType**: The unitType for this dataset measure column. Must be one of: FAMILIE, FORETAK, HUSHOLDNING, JOBB, KJORETOY, KOMMUNE, KURS, PERSON or VIRKSOMHET.
 * **name**: Human readable name(Label) of the measure column. This should be similar to your dataset name. Example for PERSON_MOR.json: "Person mor".
 * **description**: Description of the column contents. Example: "Personens registrerte biologiske mor... "
@@ -87,15 +87,15 @@ We expect all values in this dataset to be either "1" or "2", as this dataset on
 
 
 ### UNIT TYPES
-* **PERSON**: Representation of a person in the microdata platform. Columns with this unit type should contain FNR.
-* **FAMILIE**: Representation of a family in the microdata platform. Columns with this unit type should contain FNR.
-* **FORETAK**: Representation of a foretak in the microdata platform. Columns with this unit type should contain ORGNR.
-* **VIRKSOMHET**: Representation of a virksomhet in the microdata platform. Columns with this unit type should contain ORGNR.
-* **HUSHOLDNING**: Representation of a husholdning in the microdata platform. Columns with this unit type should contain FNR.
-* **JOBB**: Representation of a job in the microdata platform. Columns with this unit type should contain FNR_ORGNR. FNR belongs to the employee and ORGNR belongs to the employer.
-* **KOMMUNE**: Representation of a kommune in the microdata platform. Columns with this unit type should contain a valid kommune number.
-* **KURS**: Representation of a course in the microdata platform. Columns with this unit type should contain FNR_KURSID. Where FNR belongs to the participant and KURSID is the NUDB course id.
-* **KJORETOY**: Representation of a vehicle in the microdata platform. Columns with this unit type should contain FNR_REGNR. Where FNR is the owner of the vehicle, and REGNR is the registration number for the vehicle.
+* **PERSON**: Representation of a person in the microdata.no platform. Columns with this unit type should contain FNR.
+* **FAMILIE**: Representation of a family in the microdata.no platform. Columns with this unit type should contain FNR.
+* **FORETAK**: Representation of a foretak in the microdata.no platform. Columns with this unit type should contain ORGNR.
+* **VIRKSOMHET**: Representation of a virksomhet in the microdata.no platform. Columns with this unit type should contain ORGNR.
+* **HUSHOLDNING**: Representation of a husholdning in the microdata.no platform. Columns with this unit type should contain FNR.
+* **JOBB**: Representation of a job in the microdata.no platform. Columns with this unit type should contain FNR_ORGNR. FNR belongs to the employee and ORGNR belongs to the employer.
+* **KOMMUNE**: Representation of a kommune in the microdata.no platform. Columns with this unit type should contain a valid kommune number.
+* **KURS**: Representation of a course in the microdata.no platform. Columns with this unit type should contain FNR_KURSID. Where FNR belongs to the participant and KURSID is the NUDB course id.
+* **KJORETOY**: Representation of a vehicle in the microdata.no platform. Columns with this unit type should contain FNR_REGNR. Where FNR is the owner of the vehicle, and REGNR is the registration number for the vehicle.
 
 ## VALIDATION
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -28,9 +28,9 @@ import microdata_validator
 Once you have your metadata and data files ready to go, they should be named and stored like this:
 ```
 my-input-directory/
-    my_dataset_name/
-        my_dataset_name.csv
-        my_dataset_name.json
+    MY_DATASET_NAME/
+        MY_DATASET_NAME.csv
+        MY_DATASET_NAME.json
 ```
 
 
@@ -38,7 +38,7 @@ Import microdata-validator in your script and validate your files:
 ```py
 from microdata_validator import validate
 
-validation_errors = validate("my-dataset-name")
+validation_errors = validate("MY_DATASET_NAME")
 
 if not validation_errors:
     print("My dataset is valid")
@@ -57,7 +57,7 @@ If you wish to use a different directory, you can use the ```input_directory```-
 from microdata_validator import validate
 
 validation_errors = validate(
-    "my-dataset-name",
+    "MY_DATASET_NAME",
     input_directory="/my/input/directory",
 )
 
@@ -88,7 +88,7 @@ If you wish to keep the temporary files after the validator has run, you can do 
 from microdata_validator import validate
 
 validation_errors = validate(
-    "my-dataset-name",
+    "MY_DATASET_NAME",
     input_directory="/my/input/directory",
     working_directory="/my/working/directory",
     keep_temporary_files=True
@@ -107,7 +107,7 @@ You can validate the metadata by itself with the validate_metadata-function:
 from microdata_validator import validate_metadata
 
 validation_errors = validate_metadata(
-    "path/to/metadata-file.json"
+    "path/to/METADATA_FILE.json"
 )
 
 if not validation_errors:
@@ -119,102 +119,48 @@ This will only check if all required fields are present, and that the metadata f
 
 
 ## Use metadata references
-When creating metadatafiles for the microdata platform, you might find that you end up repeating yourself in each dataset.
-As an example, each of the files in the [examples folder](/docs/examples) has these same attribute variables:
-```json
-"attributeVariables": [
-    {
-      "variableRole": "START_TIME",
-      "shortName": "START",
-      "name": [
-        {"languageCode": "no", "value": "Startdato"},
-        {"languageCode": "en", "value": "Start date"}
-      ],
-      "description": [{"languageCode": "no", "value": "Startdato/måletidspunktet for hendelsen"}
-      ],
-      "dataType": "DATE",
-      "valueDomain": {
-        "description": [{"languageCode": "no", "value": "Dato oppgitt i dager siden 1970-01-01"}]
-      }
-    },
-    {
-      "variableRole": "STOP_TIME",
-      "shortName": "STOP",
-      "name": [
-        {"languageCode": "no", "value": "Stoppdato"},
-        {"languageCode": "en", "value": "Stop date"}
-      ],
-      "description": [
-        {"languageCode": "no", "value": "Stoppdato/sluttdato for hendelsen"},
-        {"languageCode": "en", "value": "Event stop/end date"}
-      ],
-      "dataType": "DATE",
-      "valueDomain": {
-        "description": [{"languageCode": "no", "value": "Dato oppgitt i dager siden 1970-01-01"}
-        ]
-      }
-    }
-]
 ```
-Imagine a scenario where you are managing 50+ datasets. The repetition is not only tedious, but a source of errors. Let's create a new directory ```/metadata_ref```, and place two files there:
+Only use this functionality when you feel comfortable with building datasets without it, and feel like it is necessary to improve your workflow.
+```
+When creating metadatafiles for the microdata platform, you might find that you end up repeating yourself in each dataset.
+As an example, BEFOLKNING_KJOENN and BEFOLKNING_SIVSTAND in the [examples folder](/docs/examples) has these same subject fields:
 ```json
-// start.json
-{
-    "variableRole": "START_TIME",
-    "shortName": "START",
-    "name": [
-      {"languageCode": "no", "value": "Startdato"},
-      {"languageCode": "en", "value": "Start date"}
-    ],
-    "description": [{"languageCode": "no", "value": "Startdato/måletidspunktet for hendelsen"}
-    ],
-    "dataType": "DATE",
-    "valueDomain": {
-    "description": [{"languageCode": "no", "value": "Dato oppgitt i dager siden 1970-01-01"}]
-    }
-}
+"subjectFields": [
+        [{"languageCode": "no", "value": "BEFOLKNING"}],
+        [{"languageCode": "no", "value": "SAMFUNN"}]
+      ]
+```
+Imagine a scenario where you are managing 50+ datasets, and find that you are repeating yourself a lot. The repetion of these fields might lead to typing errors. Let's create a new directory ```/metadata_ref```, and place two files there:
+```json
+//befolkning.json
+[{"languageCode": "no", "value": "BEFOLKNING"}]
 ```
 
 ```json
-// stop.json
-{
-    "variableRole": "STOP_TIME",
-    "shortName": "STOP",
-    "name": [
-      {"languageCode": "no", "value": "Stoppdato"},
-      {"languageCode": "en", "value": "Stop date"}
-    ],
-    "description": [
-      {"languageCode": "no", "value": "Stoppdato/sluttdato for hendelsen"},
-      {"languageCode": "en", "value": "Event stop/end date"}
-    ],
-    "dataType": "DATE",
-    "valueDomain": {
-    "description": [{"languageCode": "no", "value": "Dato oppgitt i dager siden 1970-01-01"}
-    ]
-}
+// samfunn.json
+[{"languageCode": "no", "value": "SAMFUNN"}]
 ```
 
 Now we can reference these files in our main dataset file:
 ```json
-"attributeVariables": [
+"subjectFields": [
     {
-      "$ref": "stop.json"
+      "$ref": "befolkning.json"
     },
     {
-      "$ref": "start.json"
+      "$ref": "samfunn.json"
     }
 ]
 ```
 By using "$ref" as the key, we can refer to a ref-file from our ref-directory. Keep in mind that we can only do this with objects, and the reference will overwrite other existing fields that may be present:
 ```json
-"attributeVariables": [
+"subjectFields": [
     {
-      "$ref": "stop.json",
+      "$ref": "befolkning.json",
       "otherfield": "this will be overwritten by the referenced file"
     },
     {
-      "$ref": "start.json"
+      "$ref": "sammfunn.json"
     }
 ]
 ```
@@ -225,7 +171,7 @@ But for the validator to know about our ref directory we need to tell it about t
 from microdata_validator import validate
 
 validation_errors = validate(
-    "my-dataset-name",
+    "MY_DATASET_NAME",
     metadata_ref_directory="metadata_ref"    
 )
 
@@ -233,7 +179,7 @@ validation_errors = validate(
 from microdata_validator import validate_metadata
 
 validation_errors = validate_metadata(
-    "path/to/metadata-file.json",
+    "path/to/MY_DATASET_NAME.json",
     metadata_ref_directory="metadata_ref"
 )
 ```
@@ -245,9 +191,9 @@ You can build an inlined file by using this function:
 from microdata_validator import inline_metadata
 
 result_file_path = validate_metadata(
-    "path/to/metadata-file.json",
+    "path/to/MY_DATASET_NAME.json",
     metadata_ref_directory="metadata_ref",
-    output_file_path="path/to/inlined-metadata.json"
+    output_file_path="path/to/INLINED_DATASET.json"
 )
 ```
 If you do not provide an output_file_path, the package will try to use the original path, but changing ".json" to "_inlined.json".

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -122,7 +122,7 @@ This will only check if all required fields are present, and that the metadata f
 ```
 Only use this functionality when you feel comfortable with building datasets without it, and feel like it is necessary to improve your workflow.
 ```
-When creating metadatafiles for the microdata platform, you might find that you end up repeating yourself in each dataset.
+When creating metadatafiles for the microdata.no platform, you might find that you end up repeating yourself in each dataset.
 As an example, BEFOLKNING_KJOENN and BEFOLKNING_SIVSTAND in the [examples folder](/docs/examples) has these same subject fields:
 ```json
 "subjectFields": [
@@ -185,7 +185,7 @@ validation_errors = validate_metadata(
 ```
 
 **IMPORTANT!**
-Remember that if you are done generating your dataset, and you want to import them into the microdata platform, we need the inlined files.
+Remember that if you are done generating your dataset, and you want to import them into the microdata.no platform, we need the inlined files.
 You can build an inlined file by using this function:
 ```py
 from microdata_validator import inline_metadata

--- a/docs/examples/SYNT_BEFOLKNING_KJOENN/SYNT_BEFOLKNING_KJOENN.json
+++ b/docs/examples/SYNT_BEFOLKNING_KJOENN/SYNT_BEFOLKNING_KJOENN.json
@@ -1,91 +1,34 @@
 {
-  "shortName": "SYNT_BEFOLKNING_KJOENN",
   "temporalityType": "FIXED",
-  "populationDescription": [{"languageCode": "no", "value": "Kjønn for en populasjon"}],
+  "populationDescription": [{"languageCode": "no", "value": "Alle personer registrert bosatt i Norge"}],
+  "sensitivityLevel": "PERSON_GENERAL",
   "spatialCoverageDescription": [{"languageCode": "no", "value": "Norge"}],
+  "subjectFields": [
+    [{"languageCode": "no", "value": "BEFOLKNING"}],
+    [{"languageCode": "no", "value": "SAMFUNN"}]
+  ],
   "dataRevision": {
     "description": [{"languageCode": "no","value": "Første publisering."}],
     "temporalEndOfSeries": false
   },
-  "identifierVariables": [
-    {
-      "variableRole": "IDENTIFIER",
-      "shortName": "PERSONID_1",
-      "name": [{"languageCode": "no", "value": "Personidentifikator"}],
-      "description": [{"languageCode": "no","value": "Identifikator for person i Microdata"}],
-      "dataType": "STRING",
-      "unitType": {
-        "shortName": "PERSON",
-        "name": [{"languageCode": "no", "value": "Person"}],
-        "description": [{"languageCode": "no", "value": "Statistisk enhet er person (individ, enkeltmenenske)"}]
-      },
-      "format": "RandomUInt48",
-      "valueDomain": {
-        "shortName": "PERSONID_1",
-        "description": [{"languageCode": "no", "value":"Pseudonymisert personnummer"}]
-      }
-    }
-  ],
+  "identifierVariables": [{"unitType": "PERSON"}],
   "measureVariables": [
     {
-      "variableRole": "MEASURE",
-      "shortName": "SYNT_BEFOLKNING_KJONN",
-      "name": [{"languageCode": "no", "value": "Kjønn"}],
-      "description": [{"languageCode": "no", "value": "Rapportert kjønn for person"}],
-      "subjectFields": [
-        [{"languageCode": "no", "value": "Helse"}],
-        [{"languageCode": "no", "value": "Helsetjenester"}]
-      ],
+      "name": [{"languageCode": "no", "value": "Befolkning kjønn"}],
+      "description": [{"languageCode": "no", "value": "Rapportert kjønn for personer"}],
       "dataType": "STRING",
-      "uriDefinition": [""],
       "valueDomain": {
-        "uriDefinition": [""],
-        "codeList": {
-          "codeItems": [
-            {
-              "code": "1",
-              "categoryTitle": [{"languageCode": "no", "value": "Mann"}],
-              "validFrom": "1900-01-01"
-            },
-            {
-              "code": "2",
-              "categoryTitle": [{"languageCode": "no", "value": "Kvinne"}],
-              "validFrom": "1900-01-01"
-            }
-          ]
-        }
-      }
-    }
-  ],
-  "attributeVariables": [
-    {
-      "variableRole": "START_TIME",
-      "shortName": "START",
-      "name": [
-        {"languageCode": "no", "value": "Startdato"},
-        {"languageCode": "en", "value": "Start date"}
-      ],
-      "description": [{"languageCode": "no", "value": "Startdato/måletidspunktet for hendelsen"}
-      ],
-      "dataType": "DATE",
-      "valueDomain": {
-        "description": [{"languageCode": "no", "value": "Dato oppgitt i dager siden 1970-01-01"}]
-      }
-    },
-    {
-      "variableRole": "STOP_TIME",
-      "shortName": "STOP",
-      "name": [
-        {"languageCode": "no", "value": "Stoppdato"},
-        {"languageCode": "en", "value": "Stop date"}
-      ],
-      "description": [
-        {"languageCode": "no", "value": "Stoppdato/sluttdato for hendelsen"},
-        {"languageCode": "en", "value": "Event stop/end date"}
-      ],
-      "dataType": "DATE",
-      "valueDomain": {
-        "description": [{"languageCode": "no", "value": "Dato oppgitt i dager siden 1970-01-01"}
+        "codeList": [
+          {
+            "code": "1",
+            "categoryTitle": [{"languageCode": "no", "value": "Mann"}],
+            "validFrom": "1900-01-01"
+          },
+          {
+            "code": "2",
+            "categoryTitle": [{"languageCode": "no", "value": "Kvinne"}],
+            "validFrom": "1900-01-01"
+          }
         ]
       }
     }

--- a/docs/examples/SYNT_BEFOLKNING_SIVSTAND/SYNT_BEFOLKNING_SIVSTAND.json
+++ b/docs/examples/SYNT_BEFOLKNING_SIVSTAND/SYNT_BEFOLKNING_SIVSTAND.json
@@ -1,91 +1,71 @@
 {
-  "shortName": "SYNT_BEFOLKNING_SIVSTAND",
   "temporalityType": "EVENT",
   "populationDescription": [{"languageCode": "no", "value": "Alle personer registrert bosatt i Norge"}],
   "spatialCoverageDescription": [{"languageCode": "no", "value": "Norge"}],
+  "subjectFields": [
+    [{"languageCode": "no", "value": "BEFOLKNING"}],
+    [{"languageCode": "no", "value": "SAMFUNN"}]
+  ],
   "dataRevision": {
     "description": [{"languageCode": "no","value": "Første publisering."}],
     "temporalEndOfSeries": false
   },
-  "identifierVariables": [
-    {
-      "shortName": "PERSONID_1",
-      "name": [{"languageCode": "no", "value": "Personidentifikator"}],
-      "description": [{"languageCode": "no","value": "Identifikator for person i Microdata"}],
-      "dataType": "STRING",
-      "unitType": {
-        "shortName": "PERSON",
-        "name": [{"languageCode": "no", "value": "Person"}],
-        "description": [{"languageCode": "no", "value": "Statistisk enhet er person (individ, enkeltmenenske)"}]
-      },
-      "format": "RandomUInt48",
-      "valueDomain": {
-        "shortName": "PERSONID_1",
-        "description": [{"languageCode": "no", "value":"Pseudonymisert personnummer"}]
-      }
-    }
-  ],
+  "identifierVariables": [{"unitType": "PERSON"}],
   "measureVariables": [
     {
-      "shortName": "SYNT_BEFOLKNING_SIVSTAND",
       "name": [{"languageCode": "no", "value": "Sivilstand"}],
       "description": [{"languageCode": "no", "value": "Sivilstand i forhold til ekteskapslovgivningen"}],
-      "subjectFields": [
-        [{"languageCode": "no", "value": "Befolkning"}]
-      ],
       "dataType": "STRING",
       "uriDefinition": ["https://www.ssb.no/a/metadata/conceptvariable/vardok/91/nb"],
       "valueDomain": {
         "uriDefinition": ["https://www.ssb.no/klass/klassifikasjoner/19"],
-        "codeList": {
-          "codeItems": [
-            {
-              "code": "1",
-              "categoryTitle": [{"languageCode": "no", "value": "Ugift"}],
-              "validFrom": "1926-01-01"
-            },
-            {
-              "code": "2",
-              "categoryTitle": [{"languageCode": "no", "value": "Gift"}],
-              "validFrom": "1926-01-01"
-            },
-            {
-              "code": "3",
-              "categoryTitle": [{"languageCode": "no", "value": "Enke/Enkemann"}],
-              "validFrom": "1926-01-01"
-            },
-            {
-              "code": "4",
-              "categoryTitle": [{"languageCode": "no", "value": "Skilt"}],
-              "validFrom": "1926-01-01"
-            },
-            {
-              "code": "5",
-              "categoryTitle": [{"languageCode": "no", "value": "Separert"}],
-              "validFrom": "1926-01-01"
-            },
-            {
-              "code": "6",
-              "categoryTitle": [{"languageCode": "no", "value": "Registrert partner"}],
-              "validFrom": "1927-07-01"
-            },
-            {
-              "code": "7",
-              "categoryTitle": [{"languageCode": "no", "value": "Separert partner"}],
-              "validFrom": "1927-07-01"
-            },
-            {
-              "code": "8",
-              "categoryTitle": [{"languageCode": "no", "value": "Skilt partner"}],
-              "validFrom": "1927-07-01"
-            },
-            {
-              "code": "9",
-              "categoryTitle": [{"languageCode": "no", "value": "Gjenlevende partner"}],
-              "validFrom": "1927-07-01"
-            }
-          ]
-        },
+        "codeList": [
+          {
+            "code": "1",
+            "categoryTitle": [{"languageCode": "no", "value": "Ugift"}],
+            "validFrom": "1926-01-01"
+          },
+          {
+            "code": "2",
+            "categoryTitle": [{"languageCode": "no", "value": "Gift"}],
+            "validFrom": "1926-01-01"
+          },
+          {
+            "code": "3",
+            "categoryTitle": [{"languageCode": "no", "value": "Enke/Enkemann"}],
+            "validFrom": "1926-01-01"
+          },
+          {
+            "code": "4",
+            "categoryTitle": [{"languageCode": "no", "value": "Skilt"}],
+            "validFrom": "1926-01-01"
+          },
+          {
+            "code": "5",
+            "categoryTitle": [{"languageCode": "no", "value": "Separert"}],
+            "validFrom": "1926-01-01"
+          },
+          {
+            "code": "6",
+            "categoryTitle": [{"languageCode": "no", "value": "Registrert partner"}],
+            "validFrom": "1927-07-01"
+          },
+          {
+            "code": "7",
+            "categoryTitle": [{"languageCode": "no", "value": "Separert partner"}],
+            "validFrom": "1927-07-01"
+          },
+          {
+            "code": "8",
+            "categoryTitle": [{"languageCode": "no", "value": "Skilt partner"}],
+            "validFrom": "1927-07-01"
+          },
+          {
+            "code": "9",
+            "categoryTitle": [{"languageCode": "no", "value": "Gjenlevende partner"}],
+            "validFrom": "1927-07-01"
+          }
+        ],
         "sentinelAndMissingValues" : [
           {
             "code": "0",
@@ -94,39 +74,6 @@
             ],
             "validFrom": "1900-01-01"
           }
-        ]
-      }
-    }
-  ],
-  "attributeVariables": [
-    {
-      "variableRole": "START_TIME",
-      "shortName": "START",
-      "name": [
-        {"languageCode": "no", "value": "Startdato"},
-        {"languageCode": "en", "value": "Start date"}
-      ],
-      "description": [{"languageCode": "no", "value": "Startdato/måletidspunktet for hendelsen"}
-      ],
-      "dataType": "DATE",
-      "valueDomain": {
-        "description": [{"languageCode": "no", "value": "Dato oppgitt i dager siden 1970-01-01"}]
-      }
-    },
-    {
-      "variableRole": "STOP_TIME",
-      "shortName": "STOP",
-      "name": [
-        {"languageCode": "no", "value": "Stoppdato"},
-        {"languageCode": "en", "value": "Stop date"}
-      ],
-      "description": [
-        {"languageCode": "no", "value": "Stoppdato/sluttdato for hendelsen"},
-        {"languageCode": "en", "value": "Event stop/end date"}
-      ],
-      "dataType": "DATE",
-      "valueDomain": {
-        "description": [{"languageCode": "no", "value": "Dato oppgitt i dager siden 1970-01-01"}
         ]
       }
     }

--- a/docs/examples/SYNT_PERSON_INNTEKT/SYNT_PERSON_INNTEKT.json
+++ b/docs/examples/SYNT_PERSON_INNTEKT/SYNT_PERSON_INNTEKT.json
@@ -1,79 +1,25 @@
 {
-  "shortName": "SYNT_PERSON_INNTEKT",
   "temporalityType": "ACCUMULATED",
-  "populationDescription": [{"languageCode": "no", "value": "Alle rapporterte personinntekter i norge fra år 1234 til år 4321"}],
+  "populationDescription": [{"languageCode": "no", "value": "Alle personer registrert bosatt i Norge"}],
   "spatialCoverageDescription": [{"languageCode": "no", "value": "Norge"}],
+  "subjectFields": [
+    [{"languageCode": "no", "value": "ØKONOMI"}],
+    [{"languageCode": "no", "value": "SAMFUNN"}]
+  ],
   "dataRevision": {
     "description": [{"languageCode": "no","value": "Første publisering."}],
     "temporalEndOfSeries": false
   },
-  "identifierVariables": [
-    {
-      "shortName": "PERSONID_1",
-      "name": [{"languageCode": "no", "value": "Personidentifikator"}],
-      "description": [{"languageCode": "no","value": "Identifikator for person i Microdata"}],
-      "dataType": "STRING",
-      "unitType": {
-        "shortName": "PERSON",
-        "name": [{"languageCode": "no", "value": "Person"}],
-        "description": [{"languageCode": "no", "value": "Statistisk enhet er person (individ, enkeltmenenske)"}]
-      },
-      "format": "RandomUInt48",
-      "valueDomain": {
-        "shortName": "PERSONID_1",
-        "description": [{"languageCode": "no", "value":"Pseudonymisert personnummer"}]
-      }
-    }
-  ], 
+  "identifierVariables": [{"unitType": "PERSON"}], 
   "measureVariables": [
     {
-      "shortName": "SYNT_PERSON_INNTEKT",
       "name": [{"languageCode": "no", "value": "Personens inntekt"}],
       "description": [{"languageCode": "no", "value": "Personens rapporterte inntekt"}],
-      "subjectFields": [
-        [{"languageCode": "no", "value": "Økonomi"}],
-        [{"languageCode": "no", "value": "Samfunn"}]
-      ],
       "dataType": "STRING",
-      "uriDefinition": [""],
       "valueDomain": {
-        "uriDefinition": [],
         "description": [{"languageCode": "no", "value":"Årlig personinntekt"}],
         "measurementType": "CURRENCY",
         "measurementUnitDescription": [{"languageCode": "no", "value": "Norske Kroner"}]
-      }
-    }
-  ],
-  "attributeVariables": [
-    {
-      "variableRole": "START_TIME",
-      "shortName": "START",
-      "name": [
-        {"languageCode": "no", "value": "Startdato"},
-        {"languageCode": "en", "value": "Start date"}
-      ],
-      "description": [{"languageCode": "no", "value": "Startdato/måletidspunktet for hendelsen"}
-      ],
-      "dataType": "DATE",
-      "valueDomain": {
-        "description": [{"languageCode": "no", "value": "Dato oppgitt i dager siden 1970-01-01"}]
-      }
-    },
-    {
-      "variableRole": "STOP_TIME",
-      "shortName": "STOP",
-      "name": [
-        {"languageCode": "no", "value": "Stoppdato"},
-        {"languageCode": "en", "value": "Stop date"}
-      ],
-      "description": [
-        {"languageCode": "no", "value": "Stoppdato/sluttdato for hendelsen"},
-        {"languageCode": "en", "value": "Event stop/end date"}
-      ],
-      "dataType": "DATE",
-      "valueDomain": {
-        "description": [{"languageCode": "no", "value": "Dato oppgitt i dager siden 1970-01-01"}
-        ]
       }
     }
   ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "microdata-validator"
-version = "4.0.0"
+version = "5.0.0"
 description = "Python package for validating datasets in the microdata platform"
 authors = ["microdata-developers"]
 license = "Apache-2.0"


### PR DESCRIPTION
# UPDATE DOCS
Updated user docs in accordance with updates to the code. Bumped major version to release the changes to PyPI. Will bump the patch version when s380 have made updates to the centrally defined unit type variables and temporal attribute variables.

### 4.0.0 => 5.0.0 Changelog
* Unit types are centrally defined
* Identifier is always defined by only one field "unitType"
* Measure variable can either be defined as before, or with "unitType", "name" and "description",  where "name" and "description" overwrites the central definitions of these fields.
* shortName removed from root fields and measure variable fields. Now injected from filename and validated to only contain upper case A-Z, number 0-9 or underscores
* CodeList contains the list directly rather than a nested "codeListItems"-list
* Subjectfields are simplified from having "shortName", "name", "description" to having just one multilanguage field. The reason for this is that we only ever used the "name" field.
* SensitivityLevel is added as a required root level field and must contain on of PERSON_GENERAL, PERSON_SPECIAL, PUBLIC or NONPUBLIC as requested by SIKT
* The centrally defined unit type variable contain a new field "pseudonymized" that, like the variables themselves, are centrally defined
* Updates to documentation and examples that reflect the changes in the component