### PR TITLE
Fix temporality bug

### DIFF
--- a/microdata_validator/steps/dataset_reader.py
+++ b/microdata_validator/steps/dataset_reader.py
@@ -139,7 +139,7 @@ def _read_and_process_data(
         logger.debug(f'{str(rows_validated)} rows validated')
         return {
             'start': min(start_dates),
-            'latest': max(stop_dates),
+            'latest': max(start_dates + stop_dates),
             'status_list': list(set(start_dates + stop_dates))
         }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "microdata-validator"
-version = "7.0.1"
+version = "7.0.2"
 description = "Python package for validating datasets in the microdata platform"
 authors = ["microdata-developers"]
 license = "Apache-2.0"

--- a/tests/resources/expected/validate/SYNT_BEFOLKNING_SIVSTAND.json
+++ b/tests/resources/expected/validate/SYNT_BEFOLKNING_SIVSTAND.json
@@ -31,7 +31,7 @@
     ],
     "temporalEndOfSeries": false,
     "temporalCoverageStart": "1920-01-01",
-    "temporalCoverageLatest": "1951-01-01"
+    "temporalCoverageLatest": "1951-01-02"
   },
   "identifierVariables": [
     {


### PR DESCRIPTION
# BUGFIX: TEMPORALITY

The testdata for SYNT_BEFOLKNING_SIVSTAND has this as the last row of the csv:
`00000000000006;3;1951-01-02;;`
where 1951-01-02 is the latest date in the dataset.

But the expected test output had this in the metadata:
```json
"temporalCoverageStart": "1920-01-01",
"temporalCoverageLatest": "1951-01-01" // this should be 1951-01-02
```

Upon changing the test data, the tests fail as expected. 
The fix is a simply including the start column when finding temporalCoverageLatest.

Bumped version from 7.0.1 to 7.0.2 (PATCH)