### PR TITLE
Filename bug

### DIFF
--- a/microdata_validator/schema/__init__.py
+++ b/microdata_validator/schema/__init__.py
@@ -29,11 +29,11 @@ def validate_with_schema(metadata_json: dict) -> None:
 def validate_dataset_name(dataset_name: str) -> None:
     valid_characters = (
         string.ascii_uppercase + '_'
-        + str(''.join(list(str(num) for num in range(0, 9))))
+        + str(''.join(list(str(num) for num in range(0, 10))))
     )
     if not all([character in valid_characters for character in dataset_name]):
         raise InvalidDatasetName(
-            f'"{dataset_name}" contains invalid characters.'
+            f'"{dataset_name}" contains invalid characters. '
             'Please use only uppercase A-Z, numbers 0-9 or "_"'
         )
 

--- a/microdata_validator/schema/__init__.py
+++ b/microdata_validator/schema/__init__.py
@@ -28,8 +28,7 @@ def validate_with_schema(metadata_json: dict) -> None:
 
 def validate_dataset_name(dataset_name: str) -> None:
     valid_characters = (
-        string.ascii_uppercase + '_'
-        + str(''.join(list(str(num) for num in range(0, 10))))
+        string.ascii_uppercase + string.digits + '_'
     )
     if not all([character in valid_characters for character in dataset_name]):
         raise InvalidDatasetName(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "microdata-validator"
-version = "7.0.2"
+version = "7.0.3"
 description = "Python package for validating datasets in the microdata platform"
 authors = ["microdata-developers"]
 license = "Apache-2.0"

--- a/tests/unit/schema/test_schema.py
+++ b/tests/unit/schema/test_schema.py
@@ -1,8 +1,12 @@
-from microdata_validator import schema
-from microdata_validator.exceptions import ParseMetadataError
-from microdata_validator.repository import local_storage
-from pathlib import Path
 import pytest
+from pathlib import Path
+
+from microdata_validator import schema
+from microdata_validator.repository import local_storage
+from microdata_validator.exceptions import (
+    ParseMetadataError, InvalidDatasetName
+)
+
 
 RESOURCES_DIR = "tests/resources/schema"
 SIMPLE_JSON = Path(f"{RESOURCES_DIR}/simple_referenced.json")
@@ -47,3 +51,17 @@ def test_inline_invalid_metadata_file_path():
         schema.inline_metadata_references(
             NONEXISTENT_FILE_PATH, REF_DIR
         )
+
+
+def test_validate_dataset_name():
+    schema.validate_dataset_name('MITT_DATASET')
+    schema.validate_dataset_name('ABCDEFGHIJKLMNOPQRSTUVWXYZ')
+    schema.validate_dataset_name('123456789')
+    schema.validate_dataset_name('1A_2Z3_334_567_GHJ')
+
+    with pytest.raises(InvalidDatasetName):
+        schema.validate_dataset_name('ÆØÅ')
+    with pytest.raises(InvalidDatasetName):
+        schema.validate_dataset_name('MY-!DÅTÆSØT-!?')
+    with pytest.raises(InvalidDatasetName):
+        schema.validate_dataset_name('MY.DATASET-!?')


### PR DESCRIPTION
# FILENAME BUG

Bug in range 0-9 resulted in dataset names with the number '9' being marked as invalid.
Added tests and fixed.

Bumped version 7.0.2 => 7.0.3 for the bugfix