### PR TITLE
Temporal variables fix

### DIFF
--- a/microdata_validator/components/temporal_attributes.py
+++ b/microdata_validator/components/temporal_attributes.py
@@ -143,7 +143,7 @@ DESCRIPTIONS = {
 }
 
 START_VARIABLE_DEFINITION = {
-    "variableRole": "START_TIME",
+    "variableRole": "Start",
     "shortName": "START",
     "dataType": "DATE",
     "valueDomain": {
@@ -156,7 +156,7 @@ START_VARIABLE_DEFINITION = {
     },
 }
 STOP_VARIABLE_DEFINITION = {
-    "variableRole": "STOP_TIME",
+    "variableRole": "Stop",
     "shortName": "STOP",
     "dataType": "DATE",
     "valueDomain": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "microdata-validator"
-version = "7.0.4"
+version = "7.0.5"
 description = "Python package for validating datasets in the microdata platform"
 authors = ["microdata-developers"]
 license = "Apache-2.0"

--- a/tests/resources/expected/validate/SYNT_BEFOLKNING_KJOENN.json
+++ b/tests/resources/expected/validate/SYNT_BEFOLKNING_KJOENN.json
@@ -152,7 +152,7 @@
   ],
   "attributeVariables": [
     {
-      "variableRole": "START_TIME",
+      "variableRole": "Start",
       "shortName": "START",
       "dataType": "DATE",
       "valueDomain": {
@@ -185,7 +185,7 @@
       ]
     },
     {
-      "variableRole": "STOP_TIME",
+      "variableRole": "Stop",
       "shortName": "STOP",
       "dataType": "DATE",
       "valueDomain": {

--- a/tests/resources/expected/validate/SYNT_BEFOLKNING_SIVSTAND.json
+++ b/tests/resources/expected/validate/SYNT_BEFOLKNING_SIVSTAND.json
@@ -228,7 +228,7 @@
   ],
   "attributeVariables": [
     {
-      "variableRole": "START_TIME",
+      "variableRole": "Start",
       "shortName": "START",
       "dataType": "DATE",
       "valueDomain": {
@@ -261,7 +261,7 @@
       ]
     },
     {
-      "variableRole": "STOP_TIME",
+      "variableRole": "Stop",
       "shortName": "STOP",
       "dataType": "DATE",
       "valueDomain": {

--- a/tests/resources/expected/validate/SYNT_PERSON_INNTEKT.json
+++ b/tests/resources/expected/validate/SYNT_PERSON_INNTEKT.json
@@ -139,7 +139,7 @@
   ],
   "attributeVariables": [
     {
-      "variableRole": "START_TIME",
+      "variableRole": "Start",
       "shortName": "START",
       "dataType": "DATE",
       "valueDomain": {
@@ -172,7 +172,7 @@
       ]
     },
     {
-      "variableRole": "STOP_TIME",
+      "variableRole": "Stop",
       "shortName": "STOP",
       "dataType": "DATE",
       "valueDomain": {

--- a/tests/resources/expected/validate/SYNT_PERSON_MOR.json
+++ b/tests/resources/expected/validate/SYNT_PERSON_MOR.json
@@ -153,7 +153,7 @@
   ],
   "attributeVariables": [
     {
-      "variableRole": "START_TIME",
+      "variableRole": "Start",
       "shortName": "START",
       "dataType": "DATE",
       "valueDomain": {
@@ -186,7 +186,7 @@
       ]
     },
     {
-      "variableRole": "STOP_TIME",
+      "variableRole": "Stop",
       "shortName": "STOP",
       "dataType": "DATE",
       "valueDomain": {

--- a/tests/resources/expected/validate/SYNT_UTDANNING.json
+++ b/tests/resources/expected/validate/SYNT_UTDANNING.json
@@ -184,7 +184,7 @@
   ],
   "attributeVariables": [
     {
-      "variableRole": "START_TIME",
+      "variableRole": "Start",
       "shortName": "START",
       "dataType": "DATE",
       "valueDomain": {
@@ -217,7 +217,7 @@
       ]
     },
     {
-      "variableRole": "STOP_TIME",
+      "variableRole": "Stop",
       "shortName": "STOP",
       "dataType": "DATE",
       "valueDomain": {

--- a/tests/resources/expected/validate_metadata/SYNT_BEFOLKNING_KJOENN.json
+++ b/tests/resources/expected/validate_metadata/SYNT_BEFOLKNING_KJOENN.json
@@ -149,7 +149,7 @@
   ],
   "attributeVariables": [
     {
-      "variableRole": "START_TIME",
+      "variableRole": "Start",
       "shortName": "START",
       "dataType": "DATE",
       "valueDomain": {
@@ -182,7 +182,7 @@
       ]
     },
     {
-      "variableRole": "STOP_TIME",
+      "variableRole": "Stop",
       "shortName": "STOP",
       "dataType": "DATE",
       "valueDomain": {

--- a/tests/resources/expected/validate_metadata/SYNT_BEFOLKNING_SIVSTAND.json
+++ b/tests/resources/expected/validate_metadata/SYNT_BEFOLKNING_SIVSTAND.json
@@ -225,7 +225,7 @@
   ],
   "attributeVariables": [
     {
-      "variableRole": "START_TIME",
+      "variableRole": "Start",
       "shortName": "START",
       "dataType": "DATE",
       "valueDomain": {
@@ -258,7 +258,7 @@
       ]
     },
     {
-      "variableRole": "STOP_TIME",
+      "variableRole": "Stop",
       "shortName": "STOP",
       "dataType": "DATE",
       "valueDomain": {

--- a/tests/resources/expected/validate_metadata/SYNT_PERSON_INNTEKT.json
+++ b/tests/resources/expected/validate_metadata/SYNT_PERSON_INNTEKT.json
@@ -136,7 +136,7 @@
   ],
   "attributeVariables": [
     {
-      "variableRole": "START_TIME",
+      "variableRole": "Start",
       "shortName": "START",
       "dataType": "DATE",
       "valueDomain": {
@@ -169,7 +169,7 @@
       ]
     },
     {
-      "variableRole": "STOP_TIME",
+      "variableRole": "Stop",
       "shortName": "STOP",
       "dataType": "DATE",
       "valueDomain": {

--- a/tests/resources/inline_metadata/SYNT_SIVSTAND_REFERENCED_INLINED.json
+++ b/tests/resources/inline_metadata/SYNT_SIVSTAND_REFERENCED_INLINED.json
@@ -167,7 +167,7 @@
   ],
   "attributeVariables": [
     {
-      "variableRole": "START_TIME",
+      "variableRole": "Start",
       "shortName": "START",
       "name": [
         {
@@ -196,7 +196,7 @@
       }
     },
     {
-      "variableRole": "STOP_TIME",
+      "variableRole": "Stop",
       "shortName": "STOP",
       "name": [
         {

--- a/tests/resources/ref_directory/attributes/start.json
+++ b/tests/resources/ref_directory/attributes/start.json
@@ -1,5 +1,5 @@
 {
-    "variableRole": "START_TIME",
+    "variableRole": "Start",
     "shortName": "START",
     "name": [
       {"languageCode": "no", "value": "Startdato"},

--- a/tests/resources/ref_directory/attributes/stop.json
+++ b/tests/resources/ref_directory/attributes/stop.json
@@ -1,5 +1,5 @@
 {
-    "variableRole": "STOP_TIME",
+    "variableRole": "Stop",
     "shortName": "STOP",
     "name": [
       {"languageCode": "no", "value": "Stoppdato"},

--- a/tests/unit/components/test_temporal_attributes.py
+++ b/tests/unit/components/test_temporal_attributes.py
@@ -11,8 +11,8 @@ def test_generate_temporal_attributes_valid_temporality():
         assert (start['dataType'], stop['dataType']) == ('DATE', 'DATE')
         assert start['shortName'] == 'START'
         assert stop['shortName'] == 'STOP'
-        assert start['variableRole'] == 'START_TIME'
-        assert stop['variableRole'] == 'STOP_TIME'
+        assert start['variableRole'] == 'Start'
+        assert stop['variableRole'] == 'Stop'
         assert 'name' in start.keys()
         assert 'description' in start.keys()
         assert 'name' in stop.keys()


### PR DESCRIPTION
# TEMPORAL VARIABLES FIX

The variable role for the start and stop variables was wrongly set by the validator which results in invalid metadata produced by the executor pipeline.

BUMPED version from 7.0.4 => 7.0.5 (PATCH)